### PR TITLE
Fix compilation issues in version 0.9.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java-library'
     id 'maven-publish'
-    id 'com.diffplug.spotless' version '6.11.0'
+    id 'com.diffplug.spotless' version '6.25.0'
 }
 
 repositories {

--- a/src/main/java/com/vapi/api/resources/logs/AsyncRawLogsClient.java
+++ b/src/main/java/com/vapi/api/resources/logs/AsyncRawLogsClient.java
@@ -140,8 +140,8 @@ public class AsyncRawLogsClient {
                     if (response.isSuccessful()) {
                         LogsPaginatedResponse parsedResponse =
                                 ObjectMappers.JSON_MAPPER.readValue(responseBody.string(), LogsPaginatedResponse.class);
-                        Optional<Double> newPageNumber =
-                                request.getPage().map(page -> page + 1).orElse(1);
+                        Optional<Double> nextPageNumber = request.getPage().map(page -> page + 1);
+                        Optional<Double> newPageNumber = nextPageNumber.isPresent() ? nextPageNumber : Optional.of(1.0);
                         LogsGetRequest nextRequest = LogsGetRequest.builder()
                                 .from(request)
                                 .page(newPageNumber)

--- a/src/main/java/com/vapi/api/resources/logs/RawLogsClient.java
+++ b/src/main/java/com/vapi/api/resources/logs/RawLogsClient.java
@@ -131,8 +131,8 @@ public class RawLogsClient {
             if (response.isSuccessful()) {
                 LogsPaginatedResponse parsedResponse =
                         ObjectMappers.JSON_MAPPER.readValue(responseBody.string(), LogsPaginatedResponse.class);
-                Optional<Double> newPageNumber =
-                        request.getPage().map(page -> page + 1).orElse(1);
+                Optional<Double> nextPageNumber = request.getPage().map(page -> page + 1);
+                Optional<Double> newPageNumber = nextPageNumber.isPresent() ? nextPageNumber : Optional.of(1.0);
                 LogsGetRequest nextRequest = LogsGetRequest.builder()
                         .from(request)
                         .page(newPageNumber)


### PR DESCRIPTION
There are a couple of issues causing the code to not compile.

The PR includes the type fixes and the plugin version upgrade required to compile the sdk.